### PR TITLE
Load maps configs always with lowercase

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -136,7 +136,7 @@ class Stripper:
 					self.compiler.AddToListVar('CXXFLAGS', '-Wno-delete-non-virtual-dtor')
 				self.compiler.AddToListVar('CDEFINES', 'HAVE_STDINT_H')
 				if self.vendor == 'gcc':
-					self.compiler.AddToListVar('CXXFLAGS', '-std=c++11')
+					self.compiler.AddToListVar('CXXFLAGS', '-std=c++14')
 					self.compiler.AddToListVar('CFLAGS', '-mfpmath=sse')
 			elif isinstance(cxx, Cpp.MSVC):
 				self.vendor = 'msvc'
@@ -199,7 +199,7 @@ class Stripper:
 				if self.vendor == 'clang':
 					self.compiler.AddToListVar('CXXFLAGS', '-Wno-implicit-exception-spec-mismatch')
 					self.compiler.AddToListVar('CXXFLAGS', '-Wno-deprecated-register')
-					self.compiler.AddToListVar('CXXFLAGS', '-std=c++11')
+					self.compiler.AddToListVar('CXXFLAGS', '-std=c++14')
 					self.compiler.AddToListVar('POSTLINKFLAGS', '-lgcc_eh')
 			elif AMBuild.target['platform'] == 'darwin':
 				self.compiler.AddToListVar('CDEFINES', 'OSX')

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -115,6 +115,7 @@ class Stripper:
 				self.compiler.AddToListVar('CDEFINES', 'POSIX')
 				self.compiler.AddToListVar('CFLAGS', '-pipe')
 				self.compiler.AddToListVar('CFLAGS', '-fno-strict-aliasing')
+				self.compiler.AddToListVar('CFLAGS', '-fno-omit-frame-pointer')
 				if (self.vendor == 'gcc' and cxx.majorVersion >= 4) or self.vendor == 'clang':
 					self.compiler.AddToListVar('CFLAGS', '-fvisibility=hidden')
 					self.compiler.AddToListVar('CXXFLAGS', '-fvisibility-inlines-hidden')

--- a/gameshim/stripper_mm.cpp
+++ b/gameshim/stripper_mm.cpp
@@ -289,8 +289,12 @@ LevelInit_handler(char const *pMapName, char const *pMapEntities, char const *c,
     if (strlen(stripper_nextfile.GetString()) > 0) {
         g_mapname.assign(stripper_nextfile.GetString());
         log_message("Loading %s for map \"%s\"", g_mapname.c_str(), pMapName);
+    } else if (stripper_lowercase.GetInt()) {
+        char* name = UTIL_ToLowerCase(pMapName);
+        g_mapname.assign(name);
+        delete[] name;
     } else {
-        g_mapname.assign(stripper_lowercase.GetInt() != 0 ? UTIL_ToLowerCase(pMapName) : pMapName);
+        g_mapname.assign(pMapName);
     }
 
     stripper_nextfile.SetValue("");

--- a/gameshim/stripper_mm.cpp
+++ b/gameshim/stripper_mm.cpp
@@ -129,6 +129,8 @@ ConVar stripper_curfile("stripper_current_file", "", FCVAR_SPONLY | FCVAR_REPLIC
 
 ConVar stripper_nextfile("stripper_next_file", "", FCVAR_PROTECTED | FCVAR_SPONLY, "Stripper for next map");
 
+ConVar stripper_lowercase("stripper_file_lowercase", "0", FCVAR_NONE, "Stripper Load Config in lowercase");
+
 #if SOURCE_ENGINE >= SE_ORANGEBOX
 void stripper_cfg_path_changed(IConVar *var, const char *pOldValue, float flOldValue)
 #else
@@ -288,7 +290,7 @@ LevelInit_handler(char const *pMapName, char const *pMapEntities, char const *c,
         g_mapname.assign(stripper_nextfile.GetString());
         log_message("Loading %s for map \"%s\"", g_mapname.c_str(), pMapName);
     } else {
-        g_mapname.assign(UTIL_ToLowerCase(pMapName));
+        g_mapname.assign(stripper_lowercase.GetInt() != 0 ? UTIL_ToLowerCase(pMapName) : pMapName);
     }
 
     stripper_nextfile.SetValue("");
@@ -298,8 +300,8 @@ LevelInit_handler(char const *pMapName, char const *pMapEntities, char const *c,
     RETURN_META_VALUE_NEWPARAMS(MRES_IGNORED, true, &IServerGameDLL::LevelInit, (pMapName, ents, c, d, e, f));
 }
 
-char
-*UTIL_ToLowerCase(const char *str)
+char*
+UTIL_ToLowerCase(const char *str)
 {
 	size_t len = strlen(str);
 	char *buffer = new char[len + 1];

--- a/gameshim/stripper_mm.cpp
+++ b/gameshim/stripper_mm.cpp
@@ -129,7 +129,7 @@ ConVar stripper_curfile("stripper_current_file", "", FCVAR_SPONLY | FCVAR_REPLIC
 
 ConVar stripper_nextfile("stripper_next_file", "", FCVAR_PROTECTED | FCVAR_SPONLY, "Stripper for next map");
 
-ConVar stripper_lowercase("stripper_file_lowercase", "0", FCVAR_NONE, "Stripper Load Config in lowercase");
+ConVar stripper_lowercase("stripper_file_lowercase", "0", FCVAR_NONE, "Load stripper configs in lowercase");
 
 #if SOURCE_ENGINE >= SE_ORANGEBOX
 void stripper_cfg_path_changed(IConVar *var, const char *pOldValue, float flOldValue)
@@ -308,7 +308,7 @@ UTIL_ToLowerCase(const char *str)
 	for (size_t i = 0; i < len; i++)
 	{
 		if (str[i] >= 'A' && str[i] <= 'Z')
-			buffer[i] = tolower(str[i]);
+			buffer[i] = str[i] - ('A' - 'a');
 		else
 			buffer[i] = str[i];
 	}

--- a/gameshim/stripper_mm.cpp
+++ b/gameshim/stripper_mm.cpp
@@ -288,7 +288,7 @@ LevelInit_handler(char const *pMapName, char const *pMapEntities, char const *c,
         g_mapname.assign(stripper_nextfile.GetString());
         log_message("Loading %s for map \"%s\"", g_mapname.c_str(), pMapName);
     } else {
-        g_mapname.assign(pMapName);
+        g_mapname.assign(UTIL_ToLowerCase(pMapName));
     }
 
     stripper_nextfile.SetValue("");
@@ -296,6 +296,22 @@ LevelInit_handler(char const *pMapName, char const *pMapEntities, char const *c,
 
     const char *ents = stripper_core.parse_map(g_mapname.c_str(), pMapEntities);
     RETURN_META_VALUE_NEWPARAMS(MRES_IGNORED, true, &IServerGameDLL::LevelInit, (pMapName, ents, c, d, e, f));
+}
+
+char
+*UTIL_ToLowerCase(const char *str)
+{
+	size_t len = strlen(str);
+	char *buffer = new char[len + 1];
+	for (size_t i = 0; i < len; i++)
+	{
+		if (str[i] >= 'A' && str[i] <= 'Z')
+			buffer[i] = tolower(str[i]);
+		else
+			buffer[i] = str[i];
+	}
+	buffer[len] = '\0';
+	return buffer;
 }
 
 bool

--- a/gameshim/stripper_mm.h
+++ b/gameshim/stripper_mm.h
@@ -59,5 +59,6 @@ PLUGIN_GLOBALVARS();
 
 const char *GetMapEntitiesString_handler();
 bool LevelInit_handler(char const *pMapName, char const *pMapEntities, char const *c, char const *d, bool e, bool f);
+char *UTIL_ToLowerCase(const char *str);
 
 #endif //_INCLUDE_SAMPLEPLUGIN_H


### PR DESCRIPTION
Sometimes map configs do not load if the case does not match.
For example, on the l4d2 game server, the campaign "c12" can be loaded either with a capital letter or with a small letter, i.e C12m1_hilltop and sometimes c12m1_hilltop. This applies to the rest of the campaign maps. After changing levels, a capital letter can go lowercase. And it absolutely does not depend on plugins, etc., just for some reason the server loads it like that, although the map bsp file is also written with a small letter. As a result, on a Linux system, you have to create two identical configuration files for one map with the same contents, which is not good. I met such a problem in other games, specifically in cs go.