### PR TITLE
Support reading map configs matching "_" splits

### DIFF
--- a/support.cpp
+++ b/support.cpp
@@ -1,5 +1,5 @@
 /** vim: set ts=4 sw=4 et tw=99:
- * 
+ *
  * === Stripper for Metamod:Source ===
  * Copyright (C) 2005-2009 David "BAILOPAN" Anderson
  * No warranties of any kind.
@@ -37,47 +37,48 @@ stripper_game_t stripper_game;
 static const char*
 parse_map(const char* map, const char* entities)
 {
-    FILE *fp;
-    char path[256];
+	FILE* fp;
+	char path[256];
 
-    g_Stripper.SetEntityList(entities);
+	g_Stripper.SetEntityList(entities);
 
-    stripper_game.path_format(path,
-            sizeof(path),
-            "%s/%s/global_filters.cfg",
-            stripper_game.game_path,
-            stripper_game.stripper_cfg_path);
-    fp = fopen(path, "rt");
-    if (fp == NULL)
-    {
-        stripper_game.log_message("Could not find global filter file: %s", path);
-    }
-    else
-    {
-        fclose(fp);
-        g_Stripper.ApplyFileFilter(path);
-    }
+	stripper_game.path_format(path,
+		sizeof(path),
+		"%s/%s/global_filters.cfg",
+		stripper_game.game_path,
+		stripper_game.stripper_cfg_path);
+	fp = fopen(path, "rt");
+	if (fp == NULL)
+	{
+		stripper_game.log_message("Could not find global filter file: %s", path);
+	}
+	else
+	{
+		fclose(fp);
+		g_Stripper.ApplyFileFilter(path);
+	}
 
-    stripper_game.path_format(path,
-            sizeof(path),
-            "%s/%s/maps/%s.cfg",
-            stripper_game.game_path,
-            stripper_game.stripper_cfg_path,
-            map);
-    fp = fopen(path, "rt");
-    if (fp)
-    {
-        fclose(fp);
-        g_Stripper.ApplyFileFilter(path);
-    }
+	for (const char* pPart = map; *pPart++ != '\0';)
+	{
+		pPart = strchrnul(pPart, '_');
+		stripper_game.path_format(path, sizeof(path), "%s/%s/maps/%.*s.cfg",
+			stripper_game.game_path, stripper_game.stripper_cfg_path, pPart - map, map);
+		fp = fopen(path, "rt");
 
-    return g_Stripper.ToString();
+		if (fp)
+		{
+			fclose(fp);
+			g_Stripper.ApplyFileFilter(path);
+		}
+	}
+
+	return g_Stripper.ToString();
 }
 
 static const char*
 ent_string()
 {
-    return g_Stripper.ToString();
+	return g_Stripper.ToString();
 }
 
 static void
@@ -86,27 +87,27 @@ command_dump()
 	char path[255];
 
 	stripper_game.path_format(path,
-            sizeof(path),
-            "%s/%s/dumps",
-            stripper_game.game_path,
-            stripper_game.stripper_path);
+		sizeof(path),
+		"%s/%s/dumps",
+		stripper_game.game_path,
+		stripper_game.stripper_path);
 
 #ifdef WIN32
 	DWORD attr = GetFileAttributes(path);
-	if ( (attr = INVALID_FILE_ATTRIBUTES) || (!(attr & FILE_ATTRIBUTE_DIRECTORY)) )
+	if ((attr = INVALID_FILE_ATTRIBUTES) || (!(attr & FILE_ATTRIBUTE_DIRECTORY)))
 	{
 		unlink(path);
 		mkdir(path);
-	}
+}
 #else
 	struct stat s;
-	
+
 	if (stat(path, &s) != 0)
 	{
 		mkdir(path, 0775);
 	}
-    else
-    {
+	else
+	{
 		if (!(S_ISDIR(s.st_mode)))
 		{
 			unlink(path);
@@ -118,7 +119,7 @@ command_dump()
 	int num = 0;
 	char file[255];
 
-	char *szMapName = (char *)stripper_game.get_map_name();
+	char* szMapName = (char*)stripper_game.get_map_name();
 
 	//Clean the mapname
 	for (int i = strlen(szMapName); i >= 0; i--)
@@ -133,18 +134,18 @@ command_dump()
 	do
 	{
 		stripper_game.path_format(file,
-                sizeof(file),
-                "%s/%s.%04d.cfg",
-                path,
-				szMapName,
-                num);
-		FILE *fp = fopen(file, "rt");
+			sizeof(file),
+			"%s/%s.%04d.cfg",
+			path,
+			szMapName,
+			num);
+		FILE* fp = fopen(file, "rt");
 		if (!fp)
 			break;
 		fclose(fp);
 	} while (++num);
 
-	FILE *fp = fopen(file, "wt");
+	FILE* fp = fopen(file, "wt");
 
 	if (!fp)
 	{
@@ -165,17 +166,17 @@ plugin_unload()
 
 static stripper_core_t stripper_core =
 {
-    parse_map,
-    ent_string,
-    command_dump,
-    plugin_unload
+	parse_map,
+	ent_string,
+	command_dump,
+	plugin_unload
 };
 
 EXPORT void
 LoadStripper(const stripper_game_t* game, stripper_core_t* core)
 {
-    memcpy(&stripper_game, game, sizeof(stripper_game_t));
-    memcpy(core, &stripper_core, sizeof(stripper_core_t));
+	memcpy(&stripper_game, game, sizeof(stripper_game_t));
+	memcpy(core, &stripper_core, sizeof(stripper_core_t));
 }
 
 /* Overload a few things to prevent libstdc++ linking */
@@ -184,22 +185,22 @@ extern "C" void __cxa_pure_virtual(void)
 {
 }
 
-void *operator new(size_t size)
+void* operator new(size_t size)
 {
 	return malloc(size);
 }
 
-void *operator new[](size_t size) 
+void* operator new[](size_t size)
 {
 	return malloc(size);
 }
 
-void operator delete(void *ptr) 
+void operator delete(void* ptr)
 {
 	free(ptr);
 }
 
-void operator delete[](void * ptr)
+void operator delete[](void* ptr)
 {
 	free(ptr);
 }


### PR DESCRIPTION
This PR provides an optimized funcionality identical to #18, whose basic idea I finally considered generic enough.

[Here](https://replit.com/@Adrianilloo/StripperMapPartsMatching#main.cpp) you can quickly check the capture groups that would be checked each iteration on maps having an arbitrary amount of underscores.

The change shouldn't break existing people's configs in that full `mapname.cfg` matches should still pass (at least).